### PR TITLE
4.0.0 - pass opts through to fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-upload-client",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "description": "Enhances Apollo Client for intuitive file uploads via GraphQL mutations.",
   "license": "MIT",
   "author": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# ![Apollo upload client](https://cdn.rawgit.com/jaydenseric/apollo-upload-client/v3.0.3/apollo-upload-logo.svg)
+# ![Apollo upload client](https://cdn.rawgit.com/jaydenseric/apollo-upload-client/v4.0.0/apollo-upload-logo.svg)
 
 ![NPM version](https://img.shields.io/npm/v/apollo-upload-client.svg?style=flat-square) ![Github issues](https://img.shields.io/github/issues/jaydenseric/apollo-upload-client.svg?style=flat-square) ![Github stars](https://img.shields.io/github/stars/jaydenseric/apollo-upload-client.svg?style=flat-square)
 

--- a/src/batch-network-interface.js
+++ b/src/batch-network-interface.js
@@ -34,13 +34,13 @@ export class HTTPUploadBatchNetworkInterface extends HTTPBatchedNetworkInterface
         return window.fetch(this._uri, {
           method: 'POST',
           body: formData,
-          ...options
+          ...options.opts
         })
       }
     }
 
     // Standard fetch method fallback
-    return super.batchedFetchFromRemoteEndpoint({requests, options})
+    return super.batchedFetchFromRemoteEndpoint({requests, options: options.opts})
   }
 }
 

--- a/src/network-interface.js
+++ b/src/network-interface.js
@@ -22,13 +22,13 @@ export class HTTPUploadNetworkInterface extends HTTPFetchNetworkInterface {
         return window.fetch(this._uri, {
           method: 'POST',
           body: formData,
-          ...options
+          ...options.opts
         })
       }
     }
 
     // Standard fetch method fallback
-    return super.fetchFromRemoteEndpoint({request, options})
+    return super.fetchFromRemoteEndpoint({request, options: options.opts})
   }
 }
 


### PR DESCRIPTION
Hi!

Passing `options.opts` down to `fetch` instead `options`.

where
```javascript
options = {
  uri: '/graphql',
  opts: {
    credentials: 'same-origin'
  }
}
```