### PR TITLE
Fix apollo-client dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "upload"
   ],
   "dependencies": {
-    "apollo-client": "^1.0.4",
+    "apollo-client": "1.x",
     "babel-runtime": "^6.23.0",
     "object-path": "^0.11.4",
     "recursive-iterator": "^2.0.3"


### PR DESCRIPTION
We're using apollo-upload-client in our project, and we need the graphql@0.10.0 update for some subscriptions stuff. As it turns out, by hardcoding a specific version of `apollo-client` we were still getting graphql@0.9.3 eventhough we updated `graphql` itself!

This commit fixes that by setting the version to `1.x`, which basically tells npm to install the latest `1.x` version.

If you'd rather hardcode the version I'll also happily set it to the newest one (`1.3.0`), but that means you'd have to release a new version of this package everytime apollo-client updates, which is... unnecessarily annoying. :blush: I think it's fair to assume this will work with any `1.x` version!