### PR TITLE
Match apollo-client createBatchingNetworkInterface

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 - Simplified React Native setup by moving Babel config out of `package.json`, fixing [#19](https://github.com/jaydenseric/apollo-upload-client/issues/19) via [#23](https://github.com/jaydenseric/apollo-upload-client/pull/23).
 - Export a new `ReactNativeFile` class to more reliably identify files for upload in React Native, via [#17](https://github.com/jaydenseric/apollo-upload-client/pull/17).
+- Renamed several exports for consistency with [`apollo-client`](http://dev.apollodata.com/core/apollo-client-api.html), via [#18](https://github.com/jaydenseric/apollo-upload-client/pull/18).
+  - `HTTPUploadNetworkInterface` renamed `UploadHTTPFetchNetworkInterface`.
+  - `HTTPUploadBatchNetworkInterface` renamed `UploadHTTPBatchedNetworkInterface`.
+  - `createBatchNetworkInterface` renamed `createBatchingNetworkInterface`.
 
 ## 4.1.1
 

--- a/readme.md
+++ b/readme.md
@@ -38,10 +38,10 @@ Alternatively enable [query batching](http://dev.apollodata.com/core/network.htm
 
 ```js
 import ApolloClient from 'apollo-client'
-import { createBatchNetworkInterface } from 'apollo-upload-client'
+import { createBatchingNetworkInterface } from 'apollo-upload-client'
 
 const client = new ApolloClient({
-  networkInterface: createBatchNetworkInterface({
+  networkInterface: createBatchingNetworkInterface({
     uri: '/graphql',
     batchInterval: 10
   })

--- a/src/batch-network-interface.js
+++ b/src/batch-network-interface.js
@@ -48,6 +48,6 @@ export class HTTPUploadBatchNetworkInterface extends HTTPBatchedNetworkInterface
   }
 }
 
-export function createBatchNetworkInterface({ uri, batchInterval, opts = {} }) {
+export function createBatchingNetworkInterface({ uri, batchInterval, opts = {} }) {
   return new HTTPUploadBatchNetworkInterface(uri, batchInterval, opts)
 }

--- a/src/batch-network-interface.js
+++ b/src/batch-network-interface.js
@@ -1,7 +1,7 @@
 import { HTTPBatchedNetworkInterface, printAST } from 'apollo-client'
 import { extractRequestFiles } from './helpers'
 
-export class HTTPUploadBatchNetworkInterface extends HTTPBatchedNetworkInterface {
+export class UploadHTTPBatchedNetworkInterface extends HTTPBatchedNetworkInterface {
   batchedFetchFromRemoteEndpoint({ requests, options }) {
     // Skip upload proccess if SSR
     if (typeof FormData !== 'undefined') {
@@ -49,5 +49,5 @@ export class HTTPUploadBatchNetworkInterface extends HTTPBatchedNetworkInterface
 }
 
 export function createBatchingNetworkInterface({ uri, batchInterval, opts = {} }) {
-  return new HTTPUploadBatchNetworkInterface(uri, batchInterval, opts)
+  return new UploadHTTPBatchedNetworkInterface(uri, batchInterval, opts)
 }

--- a/src/network-interface.js
+++ b/src/network-interface.js
@@ -1,7 +1,7 @@
 import { HTTPFetchNetworkInterface, printAST } from 'apollo-client'
 import { extractRequestFiles } from './helpers'
 
-export class HTTPUploadNetworkInterface extends HTTPFetchNetworkInterface {
+export class UploadHTTPFetchNetworkInterface extends HTTPFetchNetworkInterface {
   fetchFromRemoteEndpoint({ request, options }) {
     // Skip upload proccess if SSR
     if (typeof FormData !== 'undefined') {
@@ -35,5 +35,5 @@ export class HTTPUploadNetworkInterface extends HTTPFetchNetworkInterface {
 }
 
 export function createNetworkInterface({ uri, opts = {} }) {
-  return new HTTPUploadNetworkInterface(uri, opts)
+  return new UploadHTTPFetchNetworkInterface(uri, opts)
 }


### PR DESCRIPTION
Just a tiny edit -- `apollo-client` has changed their batch API to `createBatchingNetworkInterface`

excellent package!