### PR TITLE
Correctly infer and set content-type

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -46,6 +46,7 @@ export const createUploadLink = (
           files.forEach(({ path, file }) =>
             fetchOptions.body.append(path, file)
           )
+          delete fetchOptions.headers['content-type']
         } else {
           fetchOptions.headers['content-type'] = 'application/json'
           fetchOptions.body = JSON.stringify(requestOperation)


### PR DESCRIPTION
Firstly, thanks for your work in getting file uploading working with Apollo.

I was testing v6.0.0-beta1 of apollo-upload-client and ran into a mysterious bug.

Context:

We have a component which will first fetch a list of items (via GraphQL), then render them in the UI. The user can then click on an item and attach a document.

When I tried to upload documents, the request would barf on the server (I use a [custom gem](https://github.com/abeland/apollo_fetch_upload_rails_middleware) to make this all work in a Rails server context). It was because the `content-type` header in the request was `application/json`.

After some (a lot because I'm new to npm debugging) debugging, I confirmed that this line(51):

```js
fetchOptions.headers['content-type'] = 'application/json'
```
was altering the original headers object which I gave when I called `createUploadLink(...)`. This is obvious in hindsight since objects are passed by reference in Javscript.

I see two possible solutions:

1. Deep clone the original given `fetchOptions` every request
2. Delete the content-type header when there are files attached and let fetch infer the content-type which it does so well today

I like (2) because it's easier.

I'm putting up this PR in case you want to go this route. I realize you may go another route to address this problem, but in the meantime I will just be using this for my project.

## Testing

The `npm build` script fails in my environment, so I just tested by copying the index.mjs file directly over and verifying that uploading a file worked in the aforementioned scenario/context. Let me know if you'd like me to test in a different way.