### PR TITLE
Set response on the context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-upload-client",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Enhances Apollo Client for intuitive file uploads via GraphQL mutations.",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-upload-client",
-  "version": "6.0.3",
+  "version": "6.0.2",
   "description": "Enhances Apollo Client for intuitive file uploads via GraphQL mutations.",
   "license": "MIT",
   "author": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -72,9 +72,9 @@ export const createUploadLink = (
 
         linkFetch(uri, fetchOptions)
           .then(response => {
+            operation.setContext({ response })
             if (!response.ok)
               throw new Error(`${response.status} (${response.statusText})`)
-            operation.setContext({ response })
             return response.json()
           })
           .then(result => {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,16 +15,8 @@ export const createUploadLink = (
   } = {}
 ) =>
   new ApolloLink(
-    operation =>
+    ({ operationName, variables, query, extensions, getContext, setContext }) =>
       new Observable(observer => {
-        const {
-          operationName,
-          variables,
-          query,
-          extensions,
-          getContext
-        } = operation
-
         const requestOperation = {
           operationName,
           variables,
@@ -72,7 +64,7 @@ export const createUploadLink = (
 
         linkFetch(uri, fetchOptions)
           .then(response => {
-            operation.setContext({ response })
+            setContext({ response })
             if (!response.ok)
               throw new Error(`${response.status} (${response.statusText})`)
             return response.json()

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,8 +15,16 @@ export const createUploadLink = (
   } = {}
 ) =>
   new ApolloLink(
-    ({ operationName, variables, query, extensions, getContext }) =>
+    operation =>
       new Observable(observer => {
+        const {
+          operationName,
+          variables,
+          query,
+          extensions,
+          getContext
+        } = operation
+
         const requestOperation = {
           operationName,
           variables,
@@ -66,6 +74,7 @@ export const createUploadLink = (
           .then(response => {
             if (!response.ok)
               throw new Error(`${response.status} (${response.statusText})`)
+            operation.setContext({ response })
             return response.json()
           })
           .then(result => {


### PR DESCRIPTION
In apollo-link the raw-response is available in the context in order to e.g. access the response headers in a afterware. 

Ive attached the response here too.

https://github.com/apollographql/apollo-link/blob/685b07dd024b2e97a0929ac841ba5e1d19aa042a/packages/apollo-link-http/src/httpLink.ts#L179