### PR TITLE
Use apollo-link-http-common, remove graphql peer dependency.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,11 @@
 
 ## Next
 
-* Updated dependencies, `graphql` peer dependency range updated for v0.13.0.
+* Updated dependencies.
+* Using [`apollo-link-utilities`](https://npm.im/apollo-link-utilities) for commonality with the official HTTP links:
+  * Removed `graphql` peer dependency.
+  * Aborting `fetch` supported.
+  * Fixes [#47](https://github.com/jaydenseric/apollo-upload-client/issues/47) and [#61](https://github.com/jaydenseric/apollo-upload-client/issues/61).
 * More robust npm scripts.
 * HTTPS `package.json` author URL.
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## Next
 
 * Updated dependencies.
-* Using [`apollo-link-utilities`](https://npm.im/apollo-link-utilities) for commonality with the official HTTP links:
+* Using [`apollo-link-http-common`](https://npm.im/apollo-link-http-common) for commonality with the official HTTP links:
   * Removed `graphql` peer dependency.
   * Aborting `fetch` supported.
   * Fixes [#47](https://github.com/jaydenseric/apollo-upload-client/issues/47) and [#61](https://github.com/jaydenseric/apollo-upload-client/issues/61).

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "browserslist": ">1%",
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.40",
+    "apollo-link-utilities": "0.0.0",
     "extract-files": "^3.1.0"
   },
   "peerDependencies": {
-    "apollo-link": "^1.0.0",
-    "graphql": "0.11 - 0.13"
+    "apollo-link": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "browserslist": ">1%",
   "dependencies": {
     "@babel/runtime": "^7.0.0-beta.40",
-    "apollo-link-utilities": "0.0.0",
+    "apollo-link-http-common": "0.0.0",
     "extract-files": "^3.1.0"
   },
   "peerDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Enhances [Apollo](https://apollographql.com) for intuitive file uploads via Grap
 Install with peer dependencies using [npm](https://npmjs.com):
 
 ```shell
-npm install apollo-upload-client apollo-link graphql
+npm install apollo-upload-client apollo-link
 ```
 
 Initialize Apollo Client with this terminating link:

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,12 +1,12 @@
 import { ApolloLink, Observable } from 'apollo-link'
 import {
+  fallbackHttpConfig,
   selectURI,
-  selectOptionsAndBody,
-  serializeBody,
-  parseAndCheckResponse,
-  createSignalIfSupported,
-  LinkUtils
-} from 'apollo-link-utilities'
+  selectHttpOptionsAndBody,
+  serializeFetchBody,
+  parseAndCheckHttpResponse,
+  createSignalIfSupported
+} from 'apollo-link-http-common'
 import extractFiles from 'extract-files'
 
 export { ReactNativeFile } from 'extract-files'
@@ -36,9 +36,9 @@ export const createUploadLink = ({
       headers: context.headers
     }
 
-    const { options, body } = selectOptionsAndBody(
+    const { options, body } = selectHttpOptionsAndBody(
       operation,
-      LinkUtils.fallbackConfig,
+      fallbackHttpConfig,
       linkConfig,
       contextConfig
     )
@@ -52,7 +52,7 @@ export const createUploadLink = ({
       // GraphQL multipart request spec:
       // https://github.com/jaydenseric/graphql-multipart-request-spec
       options.body = new FormData()
-      options.body.append('operations', serializeBody(body))
+      options.body.append('operations', serializeFetchBody(body))
       options.body.append(
         'map',
         JSON.stringify(
@@ -65,7 +65,7 @@ export const createUploadLink = ({
       files.forEach(({ file }, index) =>
         options.body.append(index, file, file.name)
       )
-    } else options.body = serializeBody(body)
+    } else options.body = serializeFetchBody(body)
 
     return new Observable(observer => {
       // Allow aborting fetch, if supported.
@@ -78,7 +78,7 @@ export const createUploadLink = ({
           operation.setContext({ response })
           return response
         })
-        .then(parseAndCheckResponse(operation))
+        .then(parseAndCheckHttpResponse(operation))
         .then(result => {
           observer.next(result)
           observer.complete()

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,91 +1,102 @@
 import { ApolloLink, Observable } from 'apollo-link'
-import { print } from 'graphql/language/printer'
+import {
+  selectURI,
+  selectOptionsAndBody,
+  serializeBody,
+  parseAndCheckResponse,
+  createSignalIfSupported,
+  LinkUtils
+} from 'apollo-link-utilities'
 import extractFiles from 'extract-files'
 
 export { ReactNativeFile } from 'extract-files'
 
 export const createUploadLink = ({
-  includeExtensions,
-  uri: linkUri = '/graphql',
-  credentials: linkCredentials,
-  headers: linkHeaders,
-  fetchOptions: linkFetchOptions = {},
-  fetch: linkFetch = fetch
-} = {}) =>
-  new ApolloLink(
-    ({ operationName, variables, query, extensions, getContext, setContext }) =>
-      new Observable(observer => {
-        const requestOperation = { query: print(query) }
+  uri: fetchUri = '/graphql',
+  fetch: linkFetch = fetch,
+  fetchOptions,
+  credentials,
+  headers,
+  includeExtensions
+} = {}) => {
+  const linkConfig = {
+    http: { includeExtensions },
+    options: fetchOptions,
+    credentials,
+    headers
+  }
 
-        if (operationName) requestOperation.operationName = operationName
-        if (Object.keys(variables).length)
-          requestOperation.variables = variables
-        if (extensions && includeExtensions)
-          requestOperation.extensions = extensions
+  return new ApolloLink(operation => {
+    const uri = selectURI(operation, fetchUri)
+    const context = operation.getContext()
+    const contextConfig = {
+      http: context.http,
+      options: context.fetchOptions,
+      credentials: context.credentials,
+      headers: context.headers
+    }
 
-        const files = extractFiles(requestOperation)
+    const { options, body } = selectOptionsAndBody(
+      operation,
+      LinkUtils.fallbackConfig,
+      linkConfig,
+      contextConfig
+    )
 
-        const {
-          uri = linkUri,
-          credentials = linkCredentials,
-          headers: contextHeaders,
-          fetchOptions: contextFetchOptions = {}
-        } = getContext()
+    const files = extractFiles(body)
 
-        const fetchOptions = {
-          ...linkFetchOptions,
-          ...contextFetchOptions,
-          headers: {
-            ...linkFetchOptions.headers,
-            ...contextFetchOptions.headers,
-            ...linkHeaders,
-            ...contextHeaders
-          },
-          method: 'POST'
-        }
+    if (files.length) {
+      // Automatically set by fetch when the body is a FormData instance.
+      delete options.headers['content-type']
 
-        if (credentials) fetchOptions.credentials = credentials
+      // GraphQL multipart request spec:
+      // https://github.com/jaydenseric/graphql-multipart-request-spec
+      options.body = new FormData()
+      options.body.append('operations', serializeBody(body))
+      options.body.append(
+        'map',
+        JSON.stringify(
+          files.reduce((map, { path }, index) => {
+            map[`${index}`] = [path]
+            return map
+          }, {})
+        )
+      )
+      files.forEach(({ file }, index) =>
+        options.body.append(index, file, file.name)
+      )
+    } else options.body = serializeBody(body)
 
-        if (files.length) {
-          // GraphQL multipart request spec:
-          // https://github.com/jaydenseric/graphql-multipart-request-spec
+    return new Observable(observer => {
+      // Allow aborting fetch, if supported.
+      const { controller, signal } = createSignalIfSupported()
+      if (controller) options.signal = signal
 
-          fetchOptions.body = new FormData()
+      linkFetch(uri, options)
+        .then(response => {
+          // Forward the response on the context.
+          operation.setContext({ response })
+          return response
+        })
+        .then(parseAndCheckResponse(operation))
+        .then(result => {
+          observer.next(result)
+          observer.complete()
+        })
+        .catch(error => {
+          if (error.name === 'AbortError')
+            // Fetch was aborted.
+            return
 
-          fetchOptions.body.append(
-            'operations',
-            JSON.stringify(requestOperation)
-          )
+          if (error.result && error.result.errors)
+            // There is a GraphQL result to forward.
+            observer.next(error.result)
 
-          fetchOptions.body.append(
-            'map',
-            JSON.stringify(
-              files.reduce((map, { path }, index) => {
-                map[`${index}`] = [path]
-                return map
-              }, {})
-            )
-          )
+          observer.error(error)
+        })
 
-          files.forEach(({ file }, index) =>
-            fetchOptions.body.append(index, file, file.name)
-          )
-        } else {
-          fetchOptions.headers['content-type'] = 'application/json'
-          fetchOptions.body = JSON.stringify(requestOperation)
-        }
-
-        linkFetch(uri, fetchOptions)
-          .then(response => {
-            setContext({ response })
-            if (!response.ok)
-              throw new Error(`${response.status} (${response.statusText})`)
-            return response.json()
-          })
-          .then(result => {
-            observer.next(result)
-            observer.complete()
-          })
-          .catch(error => observer.error(error))
-      })
-  )
+      // Abort fetch as the optional cleanup function.
+      if (controller) return controller.abort
+    })
+  })
+}


### PR DESCRIPTION
* Using [`apollo-link-http-common`](https://npm.im/apollo-link-http-common) ([apollographql/apollo-link#364](https://github.com/apollographql/apollo-link/pull/364)) for commonality with the official HTTP links:
  * Removed `graphql` peer dependency.
  * Aborting `fetch` supported.
  * Fixes [#47](https://github.com/jaydenseric/apollo-upload-client/issues/47) and [#61](https://github.com/jaydenseric/apollo-upload-client/issues/61).