### PR TITLE
Make it possible to catch network errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,10 +89,6 @@ export const createUploadLink = ({
             // Fetch was aborted.
             return
 
-          if (error.result && error.result.errors && error.result.data)
-            // There is a GraphQL result to forward.
-            observer.next(error.result)
-
           observer.error(error)
         })
 


### PR DESCRIPTION
As in the issue https://github.com/apollographql/apollo-link/issues/542 when raising an error and returning a value with observable it will end in an unhandled Promise rejection thats impossible to catch. To reproduce this error it's enough to return a status code > 300 from graphql server.

 This change will fix that problem but at the same time currently it looses the possibility to read the recovered value.

