### PR TITLE
allow headers to be set via function or object

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,8 @@ Creates a terminating [Apollo Link](https://apollographql.com/docs/link) capable
 | `options.fetch`             | [function](https://mdn.io/function)?          | [`fetch`](https://fetch.spec.whatwg.org) implementation to use, defaulting to the `fetch` global. |
 | `options.fetchOptions`      | [FetchOptions](#type-fetchoptions)?           | `fetch` options; overridden by upload requirements.                                               |
 | `options.credentials`       | [string](https://mdn.io/string)?              | Overrides `options.fetchOptions.credentials`.                                                     |
-| `options.headers`           | [Object](https://mdn.io/object)? / [Function](https://mdn.io/function)?              | Merges with and overrides `options.fetchOptions.headers`.                                         |
+| `options.headers`           | [Object](https://mdn.io/object)?              | Merges with and overrides `options.fetchOptions.headers`.                                         |
+|                             | [function](https://mdn.io/function)?          |                                                                                                   |
 | `options.includeExtensions` | [boolean](https://mdn.io/boolean)? = `false`  | Toggles sending `extensions` fields to the GraphQL server.                                        |
 
 **Returns:** ApolloLink — A terminating [Apollo Link](https://apollographql.com/docs/link) capable of file uploads.

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ Creates a terminating [Apollo Link](https://apollographql.com/docs/link) capable
 | `options.fetch`             | [function](https://mdn.io/function)?          | [`fetch`](https://fetch.spec.whatwg.org) implementation to use, defaulting to the `fetch` global. |
 | `options.fetchOptions`      | [FetchOptions](#type-fetchoptions)?           | `fetch` options; overridden by upload requirements.                                               |
 | `options.credentials`       | [string](https://mdn.io/string)?              | Overrides `options.fetchOptions.credentials`.                                                     |
-| `options.headers`           | [Object](https://mdn.io/object)?[Function](https://mdn.io/function)              | Merges with and overrides `options.fetchOptions.headers`.                                         |
+| `options.headers`           | [Object](https://mdn.io/object)? / [Function](https://mdn.io/function)?              | Merges with and overrides `options.fetchOptions.headers`.                                         |
 | `options.includeExtensions` | [boolean](https://mdn.io/boolean)? = `false`  | Toggles sending `extensions` fields to the GraphQL server.                                        |
 
 **Returns:** ApolloLink — A terminating [Apollo Link](https://apollographql.com/docs/link) capable of file uploads.

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ Creates a terminating [Apollo Link](https://apollographql.com/docs/link) capable
 | `options.fetch`             | [function](https://mdn.io/function)?          | [`fetch`](https://fetch.spec.whatwg.org) implementation to use, defaulting to the `fetch` global. |
 | `options.fetchOptions`      | [FetchOptions](#type-fetchoptions)?           | `fetch` options; overridden by upload requirements.                                               |
 | `options.credentials`       | [string](https://mdn.io/string)?              | Overrides `options.fetchOptions.credentials`.                                                     |
-| `options.headers`           | [Object](https://mdn.io/object)?              | Merges with and overrides `options.fetchOptions.headers`.                                         |
+| `options.headers`           | [Object](https://mdn.io/object)?[Function](https://mdn.io/function)              | Merges with and overrides `options.fetchOptions.headers`.                                         |
 | `options.includeExtensions` | [boolean](https://mdn.io/boolean)? = `false`  | Toggles sending `extensions` fields to the GraphQL server.                                        |
 
 **Returns:** ApolloLink — A terminating [Apollo Link](https://apollographql.com/docs/link) capable of file uploads.

--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,8 @@ exports.createUploadLink = ({
   headers,
   includeExtensions
 } = {}) => {
+  if (typeof headers === 'function') headers = headers()
+
   const linkConfig = {
     http: { includeExtensions },
     options: fetchOptions,


### PR DESCRIPTION
Hi @jaydenseric 

This PR allows headers to be set via a function, so tokens can be set after the initial calling of `createUploadLink`.  This solves a problem that I have with the time at which my angular application and my token not being available until later in the application lifecycle (like after a user logs in).