### PR TITLE
Support fetchOptions signal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Updated dev dependencies.
 - Added the [`eslint-plugin-jsdoc`](https://npm.im/eslint-plugin-jsdoc) dev dependency.
 - Replaced the [`size-limit`](https://npm.im/size-limit) dev dependency with [`@size-limit/preset-small-lib`](https://npm.im/@size-limit/preset-small-lib).
+- Only create a default [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) instance if `signal` is not already set in fetch options, fixing [#162](https://github.com/jaydenseric/apollo-upload-client/issues/162) via [#169](https://github.com/jaydenseric/apollo-upload-client/pull/169).
 - Use GitHub Actions instead of Travis for CI.
 - Clarified that Opera Mini isn’t supported in the Browserslist queries and readme “Support” section.
 - Documented polyfills to consider in the readme “Support” section.

--- a/src/index.js
+++ b/src/index.js
@@ -170,8 +170,12 @@ exports.createUploadLink = ({
 
     return new Observable(observer => {
       // Allow aborting fetch, if supported.
-      const { controller, signal } = createSignalIfSupported()
-      if (controller) options.signal = signal
+      let controller
+      if (!options.signal) {
+        const { controller: _controller, signal } = createSignalIfSupported()
+        controller = _controller
+        if (controller) options.signal = signal
+      }
 
       linkFetch(uri, options)
         .then(response => {


### PR DESCRIPTION
This is a port of https://github.com/apollographql/apollo-link/commit/eb68b529a837684f8993be851a0547f0b1b73ad2

Solves https://github.com/jaydenseric/apollo-upload-client/issues/162

Steps to reproduce:
```js
const abortController = new AbortController();
const { signal } = abortController;

SomeMutation({
  …
  context: {
    fetchOptions: { signal }
   },
 });

…

abortController.abort();
```

Without the fix calling abortController doesn't have any effects.
