### PR TITLE
Add graphql to peerDependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # apollo-upload-client changelog
 
+## Next
+
+### Patch
+
+- Added the [`graphql`](https://npm.im/graphql) peer dependency to support a wider range of package managers, via [#196](https://github.com/jaydenseric/apollo-upload-client/pull/196).
+
 ## 13.0.0
 
 ### Major

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "node": ">=10"
   },
   "browserslist": "Node >= 10, > 0.5%, not OperaMini all, not dead",
+  "peerDependencies": {
+    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
   "dependencies": {
     "@babel/runtime": "^7.9.2",
     "apollo-link": "^1.2.12",
     "apollo-link-http-common": "^0.2.14",
     "extract-files": "^8.0.0"
-  },
-  "peerDependencies": {
-    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "apollo-link-http-common": "^0.2.14",
     "extract-files": "^8.0.0"
   },
+  "peerDependencies": {
+    "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
Quick PR to support yarn berry. As apollo-link and apollo-link-http-common have graphql as a peerDependencies this package should also have it 