### PR TITLE
Support clientAwareness being undefined in Apollo Link context

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - Use [`revertable-globals`](https://npm.im/revertable-globals) for tests.
 - Removed no longer necessary [`formdata-node`](https://npm.im/formdata-node) workarounds in tests.
 - Removed `npm-debug.log` from the `.gitignore` file as npm [v4.2.0](https://github.com/npm/npm/releases/tag/v4.2.0)+ doesn’t create it in the current working directory.
+- Support `clientAwareness` being undefined in Apollo Link context, via [#212](https://github.com/jaydenseric/apollo-upload-client/pull/212).
 
 ## 14.1.0
 

--- a/src/public/createUploadLink.js
+++ b/src/public/createUploadLink.js
@@ -93,7 +93,7 @@ module.exports = function createUploadLink({
       // Apollo Studio client awareness `name` and `version` can be configured
       // via `ApolloClient` constructor options:
       // https://apollographql.com/docs/studio/client-awareness/#using-apollo-server-and-apollo-client
-      clientAwareness: { name, version },
+      clientAwareness: { name, version } = {},
       headers,
     } = context;
 


### PR DESCRIPTION
Just a small tweak that ensures `createUploadLink` doesn't break if `clientAwareness` is undefined. `clientAwareness` will always be defined when using a link through an ApolloClient instance, but may be undefined in other contexts (like if calling `execute` directly instead), so we shouldn't assume it will always be defined.