### PR TITLE
Remove the subscriptions-transport-ws peer dependency

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # apollo-upload-client changelog
 
+## Next
+
+### Patch
+
+- Removed the [`subscriptions-transport-ws`](https://npm.im/subscriptions-transport-ws) peer dependency, via [#235](https://github.com/jaydenseric/apollo-upload-client/pull/235).
+
 ## 14.1.2
 
 ### Patch

--- a/package.json
+++ b/package.json
@@ -45,11 +45,10 @@
   },
   "browserslist": "Node 10.17 - 11 and Node < 11, Node 12 - 13 and Node < 13, Node >= 13.7, > 0.5%, not OperaMini all, not dead",
   "peerDependencies": {
-    "graphql": "14 - 15",
-    "subscriptions-transport-ws": "^0.9.0"
+    "graphql": "14 - 15"
   },
   "dependencies": {
-    "@apollo/client": "^3.1.5",
+    "@apollo/client": "^3.2.1",
     "@babel/runtime": "^7.11.2",
     "extract-files": "^9.0.0"
   },


### PR DESCRIPTION
Because @apollo/client is declared as a hard dependencies, and it
itself declare its own dependencies, there is no need to match them here,
since we don't reference any of those packages in our code.
