### PR TITLE
Node 14+ compatibility fix

### DIFF
--- a/public/ReactNativeFile.js
+++ b/public/ReactNativeFile.js
@@ -34,4 +34,6 @@
  * });
  * ```
  */
-module.exports = require("extract-files/public/ReactNativeFile.js");
+const {ReactNativeFile} = require('extract-files');
+
+module.exports = ReactNativeFile

--- a/public/createUploadLink.js
+++ b/public/createUploadLink.js
@@ -10,7 +10,7 @@ const {
   selectURI,
   serializeFetchParameter,
 } = require("@apollo/client/link/http");
-const extractFiles = require("extract-files/public/extractFiles.js");
+const { extractFiles } = require("extract-files");
 const formDataAppendFile = require("./formDataAppendFile.js");
 const isExtractableFile = require("./isExtractableFile.js");
 

--- a/public/isExtractableFile.js
+++ b/public/isExtractableFile.js
@@ -26,4 +26,6 @@
  * const isExtractableFile = require("apollo-upload-client/public/isExtractableFile.js");
  * ```
  */
-module.exports = require("extract-files/public/isExtractableFile.js");
+const {isExtractableFile} = require('extract-files');
+
+module.exports = isExtractableFile


### PR DESCRIPTION
This PR fix errors related to npm package `extract-file` imports that no longer works with recent version of node (at least v18.x.x and v19.x.x).
It seems that `extract-file` npm package.json prevent node from importing directly from files within public directory.


Here is the errors I got:
> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './public/extractFiles' is not defined by "exports" in [...]/node_modules/extract-files/package.json

same goes for two other exports:

> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './public/isExtractableFile' is not defined by "exports" in [...]/node_modules/extract-files/package.json

and

> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './public/ReactNativeFile' is not defined by "exports" in [...]/node_modules/extract-files/package.jsonx

As `extract-file` index.js exports these directly I've just updated the imports.